### PR TITLE
[WIP] Swift 3.0 / Xcode 8 Support

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" "swift-3.0"
-github "Quick/Nimble" "master"
+github "Quick/Quick" ~> 0.10
+github "Quick/Nimble" ~> 5.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 0.9.0
-github "Quick/Nimble" ~> 3.0.0
+github "norio-nomura/Quick" "nn-swift-3-compatibility"
+github "norio-nomura/Nimble" "nn-swift-3-compatibility"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "norio-nomura/Quick" "nn-swift-3-compatibility"
-github "norio-nomura/Nimble" "nn-swift-3-compatibility"
+github "Quick/Quick" "swift-3.0"
+github "Quick/Nimble" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v3.1.0"
-github "Quick/Quick" "v0.9.0"
+github "norio-nomura/Nimble" "fd248426eb8692b4616c2b842fcb9a2579b964e8"
+github "norio-nomura/Quick" "d3980a8bbafb13a973cb3018490e6577ee8307fd"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "fcc28b23f57b30382e5f182c238674694d7174cb"
-github "Quick/Quick" "8f2bc636ecfa2cc20696f62548b38d4ab943e299"
+github "Quick/Nimble" "v5.1.1"
+github "Quick/Quick" "v0.10.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "norio-nomura/Nimble" "fd248426eb8692b4616c2b842fcb9a2579b964e8"
-github "norio-nomura/Quick" "d3980a8bbafb13a973cb3018490e6577ee8307fd"
+github "Quick/Nimble" "fcc28b23f57b30382e5f182c238674694d7174cb"
+github "Quick/Quick" "8f2bc636ecfa2cc20696f62548b38d4ab943e299"

--- a/MockHTTP.xcodeproj/project.pbxproj
+++ b/MockHTTP.xcodeproj/project.pbxproj
@@ -82,7 +82,7 @@
 		8956355F1ACBAD6800CA60E9 /* MockHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MockHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		895635631ACBAD6800CA60E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		895635641ACBAD6800CA60E9 /* MockHTTP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockHTTP.h; sourceTree = "<group>"; };
-		8956356A1ACBAD6900CA60E9 /* MockHTTPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MockHTTPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8956356A1ACBAD6900CA60E9 /* MockHTTP-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MockHTTP-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		895635701ACBAD6900CA60E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8956357B1ACBAE4800CA60E9 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		8956357C1ACBAE4800CA60E9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = SOURCE_ROOT; };
@@ -94,7 +94,7 @@
 		895635911ACBC0A500CA60E9 /* MockHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MockHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		895635941ACBC0A500CA60E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		895635951ACBC0A500CA60E9 /* MockHTTP-OSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MockHTTP-OSX.h"; sourceTree = "<group>"; };
-		8956359B1ACBC0A500CA60E9 /* MockHTTP-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MockHTTP-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8956359B1ACBC0A500CA60E9 /* MockHTTP-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MockHTTP-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		895635A11ACBC0A500CA60E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		895635B11ACBC1EE00CA60E9 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		895635B21ACBC1EE00CA60E9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
@@ -153,9 +153,9 @@
 			isa = PBXGroup;
 			children = (
 				8956355F1ACBAD6800CA60E9 /* MockHTTP.framework */,
-				8956356A1ACBAD6900CA60E9 /* MockHTTPTests.xctest */,
+				8956356A1ACBAD6900CA60E9 /* MockHTTP-iOSTests.xctest */,
 				895635911ACBC0A500CA60E9 /* MockHTTP.framework */,
-				8956359B1ACBC0A500CA60E9 /* MockHTTP-OSXTests.xctest */,
+				8956359B1ACBC0A500CA60E9 /* MockHTTP-macOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -258,9 +258,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		8956355E1ACBAD6800CA60E9 /* MockHTTP */ = {
+		8956355E1ACBAD6800CA60E9 /* MockHTTP-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 895635751ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP" */;
+			buildConfigurationList = 895635751ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-iOS" */;
 			buildPhases = (
 				8956355A1ACBAD6800CA60E9 /* Sources */,
 				8956355B1ACBAD6800CA60E9 /* Frameworks */,
@@ -271,14 +271,14 @@
 			);
 			dependencies = (
 			);
-			name = MockHTTP;
+			name = "MockHTTP-iOS";
 			productName = MockHTTP;
 			productReference = 8956355F1ACBAD6800CA60E9 /* MockHTTP.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		895635691ACBAD6900CA60E9 /* MockHTTPTests */ = {
+		895635691ACBAD6900CA60E9 /* MockHTTP-iOSTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 895635781ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTPTests" */;
+			buildConfigurationList = 895635781ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-iOSTests" */;
 			buildPhases = (
 				895635661ACBAD6900CA60E9 /* Sources */,
 				895635671ACBAD6900CA60E9 /* Frameworks */,
@@ -290,14 +290,14 @@
 			dependencies = (
 				8956356D1ACBAD6900CA60E9 /* PBXTargetDependency */,
 			);
-			name = MockHTTPTests;
+			name = "MockHTTP-iOSTests";
 			productName = MockHTTPTests;
-			productReference = 8956356A1ACBAD6900CA60E9 /* MockHTTPTests.xctest */;
+			productReference = 8956356A1ACBAD6900CA60E9 /* MockHTTP-iOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		895635901ACBC0A500CA60E9 /* MockHTTP-OSX */ = {
+		895635901ACBC0A500CA60E9 /* MockHTTP-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 895635A41ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-OSX" */;
+			buildConfigurationList = 895635A41ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-macOS" */;
 			buildPhases = (
 				8956358C1ACBC0A500CA60E9 /* Sources */,
 				8956358D1ACBC0A500CA60E9 /* Frameworks */,
@@ -308,14 +308,14 @@
 			);
 			dependencies = (
 			);
-			name = "MockHTTP-OSX";
+			name = "MockHTTP-macOS";
 			productName = "MockHTTP-OSX";
 			productReference = 895635911ACBC0A500CA60E9 /* MockHTTP.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		8956359A1ACBC0A500CA60E9 /* MockHTTP-OSXTests */ = {
+		8956359A1ACBC0A500CA60E9 /* MockHTTP-macOSTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 895635A71ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-OSXTests" */;
+			buildConfigurationList = 895635A71ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-macOSTests" */;
 			buildPhases = (
 				895635971ACBC0A500CA60E9 /* Sources */,
 				895635981ACBC0A500CA60E9 /* Frameworks */,
@@ -327,9 +327,9 @@
 			dependencies = (
 				8956359E1ACBC0A500CA60E9 /* PBXTargetDependency */,
 			);
-			name = "MockHTTP-OSXTests";
+			name = "MockHTTP-macOSTests";
 			productName = "MockHTTP-OSXTests";
-			productReference = 8956359B1ACBC0A500CA60E9 /* MockHTTP-OSXTests.xctest */;
+			productReference = 8956359B1ACBC0A500CA60E9 /* MockHTTP-macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -373,10 +373,10 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				8956355E1ACBAD6800CA60E9 /* MockHTTP */,
-				895635691ACBAD6900CA60E9 /* MockHTTPTests */,
-				895635901ACBC0A500CA60E9 /* MockHTTP-OSX */,
-				8956359A1ACBC0A500CA60E9 /* MockHTTP-OSXTests */,
+				8956355E1ACBAD6800CA60E9 /* MockHTTP-iOS */,
+				895635691ACBAD6900CA60E9 /* MockHTTP-iOSTests */,
+				895635901ACBC0A500CA60E9 /* MockHTTP-macOS */,
+				8956359A1ACBC0A500CA60E9 /* MockHTTP-macOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -458,12 +458,12 @@
 /* Begin PBXTargetDependency section */
 		8956356D1ACBAD6900CA60E9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 8956355E1ACBAD6800CA60E9 /* MockHTTP */;
+			target = 8956355E1ACBAD6800CA60E9 /* MockHTTP-iOS */;
 			targetProxy = 8956356C1ACBAD6900CA60E9 /* PBXContainerItemProxy */;
 		};
 		8956359E1ACBC0A500CA60E9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 895635901ACBC0A500CA60E9 /* MockHTTP-OSX */;
+			target = 895635901ACBC0A500CA60E9 /* MockHTTP-macOS */;
 			targetProxy = 8956359D1ACBC0A500CA60E9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -571,7 +571,7 @@
 				INFOPLIST_FILE = MockHTTP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MockHTTP;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -589,7 +589,7 @@
 				INFOPLIST_FILE = MockHTTP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = MockHTTP;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
 			};
@@ -599,7 +599,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
@@ -618,7 +617,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
@@ -725,7 +723,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		895635751ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP" */ = {
+		895635751ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				895635761ACBAD6900CA60E9 /* Debug */,
@@ -734,7 +732,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		895635781ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTPTests" */ = {
+		895635781ACBAD6900CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-iOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				895635791ACBAD6900CA60E9 /* Debug */,
@@ -743,7 +741,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		895635A41ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-OSX" */ = {
+		895635A41ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				895635A51ACBC0A500CA60E9 /* Debug */,
@@ -752,7 +750,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		895635A71ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-OSXTests" */ = {
+		895635A71ACBC0A500CA60E9 /* Build configuration list for PBXNativeTarget "MockHTTP-macOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				895635A81ACBC0A500CA60E9 /* Debug */,

--- a/MockHTTP.xcodeproj/project.pbxproj
+++ b/MockHTTP.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -547,6 +548,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -638,7 +640,6 @@
 				INFOPLIST_FILE = "MockHTTP-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = MockHTTP;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -658,7 +659,6 @@
 				INFOPLIST_FILE = "MockHTTP-OSX/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = MockHTTP;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/MockHTTP.xcodeproj/project.pbxproj
+++ b/MockHTTP.xcodeproj/project.pbxproj
@@ -345,9 +345,11 @@
 				TargetAttributes = {
 					8956355E1ACBAD6800CA60E9 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					895635691ACBAD6900CA60E9 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					895635901ACBC0A500CA60E9 = {
 						CreatedOnToolsVersion = 6.3;
@@ -572,6 +574,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -588,6 +591,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -606,6 +610,7 @@
 				INFOPLIST_FILE = MockHTTPTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -620,6 +625,7 @@
 				INFOPLIST_FILE = MockHTTPTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/MockHTTP.xcodeproj/project.pbxproj
+++ b/MockHTTP.xcodeproj/project.pbxproj
@@ -351,9 +351,11 @@
 					};
 					895635901ACBC0A500CA60E9 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					8956359A1ACBC0A500CA60E9 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -640,6 +642,7 @@
 				PRODUCT_NAME = MockHTTP;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -659,6 +662,7 @@
 				PRODUCT_NAME = MockHTTP;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -681,6 +685,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -698,6 +703,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-iOS.xcscheme
+++ b/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
-               BuildableName = "MockHTTP-iOS.framework"
+               BuildableName = "MockHTTP.framework"
                BlueprintName = "MockHTTP-iOS"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
-            BuildableName = "MockHTTP-iOS.framework"
+            BuildableName = "MockHTTP.framework"
             BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
@@ -79,7 +79,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
-            BuildableName = "MockHTTP-iOS.framework"
+            BuildableName = "MockHTTP.framework"
             BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
@@ -97,7 +97,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
-            BuildableName = "MockHTTP-iOS.framework"
+            BuildableName = "MockHTTP.framework"
             BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>

--- a/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-iOS.xcscheme
+++ b/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-iOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "895635901ACBC0A500CA60E9"
-               BuildableName = "MockHTTP.framework"
-               BlueprintName = "MockHTTP-OSX"
+               BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+               BuildableName = "MockHTTP-iOS.framework"
+               BlueprintName = "MockHTTP-iOS"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8956359A1ACBC0A500CA60E9"
-               BuildableName = "MockHTTP-OSXTests.xctest"
-               BlueprintName = "MockHTTP-OSXTests"
+               BlueprintIdentifier = "895635691ACBAD6900CA60E9"
+               BuildableName = "MockHTTP-iOSTests.xctest"
+               BlueprintName = "MockHTTP-iOSTests"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -46,9 +46,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8956359A1ACBC0A500CA60E9"
-               BuildableName = "MockHTTP-OSXTests.xctest"
-               BlueprintName = "MockHTTP-OSXTests"
+               BlueprintIdentifier = "895635691ACBAD6900CA60E9"
+               BuildableName = "MockHTTP-iOSTests.xctest"
+               BlueprintName = "MockHTTP-iOSTests"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -56,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
-            BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP-OSX"
+            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BuildableName = "MockHTTP-iOS.framework"
+            BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -78,9 +78,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
-            BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP-OSX"
+            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BuildableName = "MockHTTP-iOS.framework"
+            BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -96,9 +96,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
-            BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP-OSX"
+            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BuildableName = "MockHTTP-iOS.framework"
+            BlueprintName = "MockHTTP-iOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-macOS.xcscheme
+++ b/MockHTTP.xcodeproj/xcshareddata/xcschemes/MockHTTP-macOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+               BlueprintIdentifier = "895635901ACBC0A500CA60E9"
                BuildableName = "MockHTTP.framework"
-               BlueprintName = "MockHTTP"
+               BlueprintName = "MockHTTP-macOS"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "895635691ACBAD6900CA60E9"
-               BuildableName = "MockHTTPTests.xctest"
-               BlueprintName = "MockHTTPTests"
+               BlueprintIdentifier = "8956359A1ACBC0A500CA60E9"
+               BuildableName = "MockHTTP-macOSTests.xctest"
+               BlueprintName = "MockHTTP-macOSTests"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -46,9 +46,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "895635691ACBAD6900CA60E9"
-               BuildableName = "MockHTTPTests.xctest"
-               BlueprintName = "MockHTTPTests"
+               BlueprintIdentifier = "8956359A1ACBC0A500CA60E9"
+               BuildableName = "MockHTTP-macOSTests.xctest"
+               BlueprintName = "MockHTTP-macOSTests"
                ReferencedContainer = "container:MockHTTP.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -56,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
             BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP"
+            BlueprintName = "MockHTTP-macOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -78,9 +78,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
             BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP"
+            BlueprintName = "MockHTTP-macOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -96,9 +96,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8956355E1ACBAD6800CA60E9"
+            BlueprintIdentifier = "895635901ACBC0A500CA60E9"
             BuildableName = "MockHTTP.framework"
-            BlueprintName = "MockHTTP"
+            BlueprintName = "MockHTTP-macOS"
             ReferencedContainer = "container:MockHTTP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/MockHTTP/MockHTTP.swift
+++ b/MockHTTP/MockHTTP.swift
@@ -85,11 +85,11 @@ public final class MockingContext {
         }
     }
 
-    public func register(_ response: URLResponse, for url: URL) {
+    public func register(response: URLResponse, for url: URL) {
         withLock { $0.responseForURL[url] = response }
     }
 
-    public func register(_ response: URLResponse, for requestFilter: @escaping RequestFilter) {
+    public func register(response: URLResponse, for requestFilter: @escaping RequestFilter) {
         withLock { $0.responseForRequestFilter.append((matcher: requestFilter, response: response)) }
     }
 

--- a/MockHTTP/MockHTTP.swift
+++ b/MockHTTP/MockHTTP.swift
@@ -55,7 +55,7 @@ public final class MockingContext {
 
     }
 
-    private func withLock<U>( _ f: @noescape (MockingContext) -> U) -> U {
+    private func withLock<U>( _ f: (MockingContext) -> U) -> U {
         return mutex.inCriticalSection { f(self) }
     }
 
@@ -89,7 +89,7 @@ public final class MockingContext {
         withLock { $0.responseForURL[url] = response }
     }
 
-    public func register(_ response: URLResponse, for requestFilter: RequestFilter) {
+    public func register(_ response: URLResponse, for requestFilter: @escaping RequestFilter) {
         withLock { $0.responseForRequestFilter.append((matcher: requestFilter, response: response)) }
     }
 

--- a/MockHTTP/MockHTTP.swift
+++ b/MockHTTP/MockHTTP.swift
@@ -85,11 +85,11 @@ public final class MockingContext {
         }
     }
 
-    public func register(response: URLResponse, for url: URL) {
+    public func register(_ response: URLResponse, for url: URL) {
         withLock { $0.responseForURL[url] = response }
     }
 
-    public func register(response: URLResponse, for requestFilter: RequestFilter) {
+    public func register(_ response: URLResponse, for requestFilter: RequestFilter) {
         withLock { $0.responseForRequestFilter.append((matcher: requestFilter, response: response)) }
     }
 

--- a/MockHTTP/Mutex.swift
+++ b/MockHTTP/Mutex.swift
@@ -38,7 +38,7 @@ final class Mutex {
     /// - parameter f: A function that performs the critical work. Can optionally return a value of generic type `U`
     ///
     /// - returns: the value that was returned by `f`.
-    func inCriticalSection<U>(@noescape f: Void -> U) -> U {
+    func inCriticalSection<U>(@noescape _ f: (Void) -> U) -> U {
         pthread_mutex_lock(&mutex)
         let returned = f()
         pthread_mutex_unlock(&mutex)

--- a/MockHTTP/Mutex.swift
+++ b/MockHTTP/Mutex.swift
@@ -38,7 +38,7 @@ final class Mutex {
     /// - parameter f: A function that performs the critical work. Can optionally return a value of generic type `U`
     ///
     /// - returns: the value that was returned by `f`.
-    func inCriticalSection<U>(@noescape _ f: (Void) -> U) -> U {
+    func inCriticalSection<U>( _ f: @noescape(Void) -> U) -> U {
         pthread_mutex_lock(&mutex)
         let returned = f()
         pthread_mutex_unlock(&mutex)

--- a/MockHTTP/Mutex.swift
+++ b/MockHTTP/Mutex.swift
@@ -38,7 +38,7 @@ final class Mutex {
     /// - parameter f: A function that performs the critical work. Can optionally return a value of generic type `U`
     ///
     /// - returns: the value that was returned by `f`.
-    func inCriticalSection<U>( _ f: @noescape(Void) -> U) -> U {
+    func inCriticalSection<U>( _ f: (Void) -> U) -> U {
         pthread_mutex_lock(&mutex)
         let returned = f()
         pthread_mutex_unlock(&mutex)

--- a/MockHTTP/URLProtocol.swift
+++ b/MockHTTP/URLProtocol.swift
@@ -38,7 +38,7 @@ public class MockURLProtocol : URLProtocol {
                 }
         } else {
             let message = "Request for URL: \(self.request.url) not registered"
-            let userInfo : [NSObject: AnyObject] = [NSLocalizedDescriptionKey: message]
+            let userInfo = [NSLocalizedDescriptionKey: message]
             let error = NSError(domain: "MockHTTP", code: 1, userInfo: userInfo)
             self.client?.urlProtocol(self, didFailWithError: error)
         }

--- a/MockHTTP/URLProtocol.swift
+++ b/MockHTTP/URLProtocol.swift
@@ -8,39 +8,39 @@
 
 import Foundation
 
-public class URLProtocol : NSURLProtocol {
-    override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
-        let result = request.URL?.scheme == "http"
+public class URLProtocol : Foundation.URLProtocol {
+    override public class func canInit(with request: URLRequest) -> Bool {
+        let result = request.url?.scheme == "http"
         return result
     }
 
-    override public class func canonicalRequestForRequest(request: NSURLRequest) -> NSURLRequest {
+    override public class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
 
-    override public class func requestIsCacheEquivalent(a: NSURLRequest, toRequest:NSURLRequest) -> Bool {
+    override public class func requestIsCacheEquivalent(_ a: URLRequest, to toRequest:URLRequest) -> Bool {
         return false
     }
 
     override public func startLoading() {
         ctx?.addRequest(self.request)
-        if  let url = self.request.URL,
+        if  let url = self.request.url,
             let response = ctx?.responseForRequest(self.request),
-            let urlResponse = NSHTTPURLResponse(URL: url, statusCode: response.statusCode, HTTPVersion: "1.1", headerFields: response.headers) {
-                self.client?.URLProtocol(self, didReceiveResponse: urlResponse, cacheStoragePolicy: .NotAllowed)
+            let urlResponse = HTTPURLResponse(url: url, statusCode: response.statusCode, httpVersion: "1.1", headerFields: response.headers) {
+                self.client?.urlProtocol(self, didReceive: urlResponse, cacheStoragePolicy: .notAllowed)
                 if let body = response.body {
-                    self.client?.URLProtocol(self, didLoadData: body)
+                    self.client?.urlProtocol(self, didLoad: body)
                 }
                 if let error = response.error {
-                    self.client?.URLProtocol(self, didFailWithError: error)
+                    self.client?.urlProtocol(self, didFailWithError: error)
                 } else {
-                    self.client?.URLProtocolDidFinishLoading(self)
+                    self.client?.urlProtocolDidFinishLoading(self)
                 }
         } else {
-            let message = "Request for URL: \(self.request.URL) not registered"
+            let message = "Request for URL: \(self.request.url) not registered"
             let userInfo : [NSObject: AnyObject] = [NSLocalizedDescriptionKey: message]
             let error = NSError(domain: "MockHTTP", code: 1, userInfo: userInfo)
-            self.client?.URLProtocol(self, didFailWithError: error)
+            self.client?.urlProtocol(self, didFailWithError: error)
         }
     }
 

--- a/MockHTTP/URLProtocol.swift
+++ b/MockHTTP/URLProtocol.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class URLProtocol : Foundation.URLProtocol {
+public class MockURLProtocol : URLProtocol {
     override public class func canInit(with request: URLRequest) -> Bool {
         let result = request.url?.scheme == "http"
         return result
@@ -23,9 +23,9 @@ public class URLProtocol : Foundation.URLProtocol {
     }
 
     override public func startLoading() {
-        ctx?.addRequest(self.request)
+        ctx?.add(self.request)
         if  let url = self.request.url,
-            let response = ctx?.responseForRequest(self.request),
+            let response = ctx?.response(for: self.request),
             let urlResponse = HTTPURLResponse(url: url, statusCode: response.statusCode, httpVersion: "1.1", headerFields: response.headers) {
                 self.client?.urlProtocol(self, didReceive: urlResponse, cacheStoragePolicy: .notAllowed)
                 if let body = response.body {

--- a/MockHTTP/URLResponse.swift
+++ b/MockHTTP/URLResponse.swift
@@ -11,10 +11,10 @@ import Foundation
 public class URLResponse {
     public let statusCode : Int
     public let headers : [String: String]
-    public let body : NSData?
+    public let body : Data?
     public let error : NSError?
 
-    public init(statusCode: Int, headers: [String:String], body: NSData?, error: NSError? = nil) {
+    public init(statusCode: Int, headers: [String:String], body: Data?, error: NSError? = nil) {
         self.statusCode = statusCode
         self.headers = headers
         self.body = body
@@ -22,12 +22,12 @@ public class URLResponse {
     }
 
     public convenience init(string: String, statusCode: Int, headers: [String: String] = [:]) {
-        let body = NSString(string: string).dataUsingEncoding(NSUTF8StringEncoding)
+        let body = NSString(string: string).data(using: String.Encoding.utf8.rawValue)
         self.init(statusCode: statusCode, headers: headers, body: body, error: nil)
     }
 
     public convenience init(json: AnyObject, statusCode: Int, headers: [String: String] = [:]) {
-        let body = try? NSJSONSerialization.dataWithJSONObject(json, options: [])
+        let body = try? JSONSerialization.data(withJSONObject: json, options: [])
         self.init(statusCode: statusCode, headers: headers, body: body, error: nil)
     }
 

--- a/MockHTTPTests/MockHTTPSpec.swift
+++ b/MockHTTPTests/MockHTTPSpec.swift
@@ -9,7 +9,7 @@ class MockHTTPSpec: QuickSpec {
         var mockingContext: MockHTTP.MockingContext!
 
         beforeEach {
-            configuration = URLSessionConfiguration.default()
+            configuration = URLSessionConfiguration.default
             mockingContext = MockingContext(configuration: configuration)
             MockHTTP.setGlobalContext(mockingContext)
         }

--- a/MockHTTPTests/MockHTTPSpec.swift
+++ b/MockHTTPTests/MockHTTPSpec.swift
@@ -4,39 +4,39 @@ import MockHTTP
 
 class MockHTTPSpec: QuickSpec {
     override func spec() {
-        let url = NSURL(string: "http://example.com/foo")!
-        var configuration: NSURLSessionConfiguration! = nil
+        let url = URL(string: "http://example.com/foo")!
+        var configuration: URLSessionConfiguration! = nil
         var mockingContext: MockHTTP.MockingContext!
 
         beforeEach {
-            configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+            configuration = URLSessionConfiguration.default()
             mockingContext = MockingContext(configuration: configuration)
             MockHTTP.setGlobalContext(mockingContext)
         }
 
         describe("mocking http requests by URL") {
-            let data = NSString(string: "hello").dataUsingEncoding(NSUTF8StringEncoding)!
+            let data = NSString(string: "hello").data(using: String.Encoding.utf8.rawValue)
             let headers = ["foo": "bar"]
             let response = MockHTTP.URLResponse(statusCode: 200, headers: headers, body: data)
 
-            var session : NSURLSession!
-            var request : NSURLRequest!
-            var httpResponse : NSHTTPURLResponse?
+            var session : URLSession!
+            var request : URLRequest!
+            var httpResponse : HTTPURLResponse?
 
             beforeEach {
                 mockingContext.registerResponse(response, forURL: url)
-                request = NSURLRequest(URL: url)
-                session = NSURLSession(configuration: configuration)
+                request = URLRequest(url: url)
+                session = URLSession(configuration: configuration)
             }
 
             it("should return the registered response") {
                 waitUntil(timeout: 1) { done in
-                    session.dataTaskWithRequest(request, completionHandler: { (body, urlResponse, error) -> Void in
-                        httpResponse = urlResponse as? NSHTTPURLResponse
+                    session.dataTask(with: request as URLRequest, completionHandler: { (body, urlResponse, error) -> Void in
+                        httpResponse = urlResponse as? HTTPURLResponse
                         expect(body).to(equal(data))
                         expect(httpResponse?.statusCode).to(equal(200))
                         expect(mockingContext.requests().count).to(equal(1))
-                        expect(mockingContext.requests().last?.URL?.absoluteString).to(equal("http://example.com/foo"))
+                        expect(mockingContext.requests().last?.url?.absoluteString).to(equal("http://example.com/foo"))
                         done()
                     }).resume()
                 }
@@ -44,33 +44,33 @@ class MockHTTPSpec: QuickSpec {
         }
 
         describe("mocking http requests for request filter") {
-            let data = NSString(string: "hello").dataUsingEncoding(NSUTF8StringEncoding)!
+            let data = NSString(string: "hello").data(using: String.Encoding.utf8.rawValue)!
             let headers = ["foo": "bar"]
             let response = MockHTTP.URLResponse(statusCode: 200, headers: headers, body: data)
 
-            var session : NSURLSession! = nil
-            var request : NSMutableURLRequest! = nil
-            var httpResponse : NSHTTPURLResponse? = nil
+            var session : URLSession! = nil
+            var request : URLRequest! = nil
+            var httpResponse : HTTPURLResponse? = nil
 
             beforeEach {
-                mockingContext.registerResponse(response) {(request: NSURLRequest) -> Bool in
-                    return request.HTTPMethod == "PUT"
+                mockingContext.registerResponse(response) {(request: URLRequest) -> Bool in
+                    return request.httpMethod == "PUT"
                 }
 
-                request = NSMutableURLRequest(URL: url)
-                request.HTTPMethod = "PUT"
+                request = URLRequest(url: url)
+                request.httpMethod = "PUT"
 
-                session = NSURLSession(configuration: configuration)
+                session = URLSession(configuration: configuration)
             }
 
             it("should return the registered response") {
                 waitUntil(timeout: 1) { done in
-                    session.dataTaskWithRequest(request, completionHandler: { (body, urlResponse, error) -> Void in
-                        httpResponse = urlResponse as? NSHTTPURLResponse
+                    session.dataTask(with: request as URLRequest, completionHandler: { (body, urlResponse, error) -> Void in
+                        httpResponse = urlResponse as? HTTPURLResponse
                         expect(body).to(equal(data))
                         expect(httpResponse?.statusCode).to(equal(200))
                         expect(mockingContext.requests().count).to(equal(1))
-                        expect(mockingContext.requests().last?.URL?.absoluteString).to(equal("http://example.com/foo"))
+                        expect(mockingContext.requests().last?.url?.absoluteString).to(equal("http://example.com/foo"))
                         done()
                     }).resume()
                 }
@@ -85,12 +85,12 @@ class MockHTTPSpec: QuickSpec {
                 }
 
                 it("should return the default response") {
-                    let request = NSURLRequest(URL: url)
-                    let session = NSURLSession(configuration: configuration)
+                    let request = URLRequest(url: url)
+                    let session = URLSession(configuration: configuration)
 
                     waitUntil(timeout: 1) { done in
-                        session.dataTaskWithRequest(request, completionHandler: { (body, urlResponse, error) in
-                            let httpResponse = urlResponse as? NSHTTPURLResponse
+                        session.dataTask(with: request as URLRequest, completionHandler: { (body, urlResponse, error) in
+                            let httpResponse = urlResponse as? HTTPURLResponse
                             expect(httpResponse?.statusCode).to(equal(404))
                             done()
                         }).resume()
@@ -100,11 +100,11 @@ class MockHTTPSpec: QuickSpec {
 
             context("without a default response") {
                 it("should fail") {
-                    let request = NSURLRequest(URL: url)
-                    let session = NSURLSession(configuration: configuration)
+                    let request = NSURLRequest(url: url)
+                    let session = URLSession(configuration: configuration)
 
                     waitUntil(timeout: 1) { done in
-                        session.dataTaskWithRequest(request, completionHandler: { (body, urlResponse, error) in
+                        session.dataTask(with: request as URLRequest, completionHandler: { (body, urlResponse, error) in
                             expect(error).toNot(beNil())
                             done()
                         }).resume()

--- a/MockHTTPTests/MockHTTPSpec.swift
+++ b/MockHTTPTests/MockHTTPSpec.swift
@@ -24,7 +24,7 @@ class MockHTTPSpec: QuickSpec {
             var httpResponse : HTTPURLResponse?
 
             beforeEach {
-                mockingContext.registerResponse(response, forURL: url)
+                mockingContext.register(response: response, for: url)
                 request = URLRequest(url: url)
                 session = URLSession(configuration: configuration)
             }
@@ -53,7 +53,7 @@ class MockHTTPSpec: QuickSpec {
             var httpResponse : HTTPURLResponse? = nil
 
             beforeEach {
-                mockingContext.registerResponse(response) {(request: URLRequest) -> Bool in
+                mockingContext.register(response: response) {(request: URLRequest) -> Bool in
                     return request.httpMethod == "PUT"
                 }
 

--- a/MockHTTPTests/URLProtocolSpec.swift
+++ b/MockHTTPTests/URLProtocolSpec.swift
@@ -4,25 +4,25 @@ import MockHTTP
 
 class URLProtocolSpec: QuickSpec {
     override func spec() {
-        var request : NSURLRequest! = nil
+        var request : URLRequest! = nil
 
         describe("with an http request") {
             beforeEach {
-                request = NSURLRequest(URL: NSURL(string: "http://example.com")!)
+                request = URLRequest(url: URL(string: "http://example.com")!)
             }
 
             it("can init request") {
-                expect(MockHTTP.URLProtocol.canInitWithRequest(request)).to(beTruthy())
+                expect(MockHTTP.URLProtocol.canInit(with: request)).to(beTruthy())
             }
         }
 
         describe("with a non-http request") {
             beforeEach {
-                request = NSURLRequest(URL: NSURL(string: "ftp://example.com")!)
+                request = URLRequest(url: URL(string: "ftp://example.com")!)
             }
 
             it("can't init request") {
-                expect(MockHTTP.URLProtocol.canInitWithRequest(request)).to(beFalsy())
+                expect(MockHTTP.URLProtocol.canInit(with: request)).to(beFalsy())
             }
         }
     }

--- a/MockHTTPTests/URLProtocolSpec.swift
+++ b/MockHTTPTests/URLProtocolSpec.swift
@@ -12,7 +12,7 @@ class URLProtocolSpec: QuickSpec {
             }
 
             it("can init request") {
-                expect(MockHTTP.URLProtocol.canInit(with: request)).to(beTruthy())
+                expect(MockURLProtocol.canInit(with: request)).to(beTruthy())
             }
         }
 
@@ -22,7 +22,7 @@ class URLProtocolSpec: QuickSpec {
             }
 
             it("can't init request") {
-                expect(MockHTTP.URLProtocol.canInit(with: request)).to(beFalsy())
+                expect(MockURLProtocol.canInit(with: request)).to(beFalsy())
             }
         }
     }


### PR DESCRIPTION
_Note_: This probably shouldn't be merged until either Xcode 8 ships, or you want to maintain a separate swift3 branch in the meantime.

I had to noodle around with the code only very little to get this all working with the latest Xcode beta and Swift 3, which is nice. Tests all pass so far, so it should be good to go. I'll start consuming this in a Swift 3 project I started recently to see how it holds up in use.
